### PR TITLE
Hotfix: Booking page overflow on mobile

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1008,7 +1008,6 @@ button { font-family: inherit; cursor: pointer; }
 .gl-credits-photo {
   position: relative;
   background: var(--bg-2);
-  border: 1px solid var(--hairline-strong);
   overflow: hidden;
   aspect-ratio: 4519 / 6775;
 }

--- a/docs/pages/booking.html
+++ b/docs/pages/booking.html
@@ -11,6 +11,11 @@
     .gl-nav--page { position: relative; flex-shrink: 0; }
     .gl-root.gl-page.gl-booking-simple { height: 100%; overflow: hidden; display: flex; flex-direction: column; }
     .gl-booking-hero { flex: 1; min-height: 0; }
+    
+    @media (max-width: 768px) {
+      html, body { overflow: auto; }
+      .gl-root.gl-page.gl-booking-simple { overflow: auto; height: auto; }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
Hotfix addresses to issues:
- Text was overflowing on the booking page on mobile
- There was a tiny border around an image on the about me page