### PR TITLE
Refactor: Extract Shared Modules for Head, Footer, and Sheet Data

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -4,15 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About — Marcus Maldonado</title>
-  <link rel="icon" type="image/x-icon" href="../assets/img/favicon.ico" />
-  <meta property="og:title" content="About — Marcus Maldonado" />
-  <meta property="og:description" content="Engineer by trade. Guitarist by passion. Equally serious about both." />
-  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
-  <meta property="og:url" content="https://marcus.band/about/" />
-  <meta property="og:type" content="website" />
-  <link rel="apple-touch-icon" href="../assets/img/apple-touch-icon.png" />
-  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../assets/css/styles.css">
+  <script>window.MM_PAGE = {
+    ogUrl: 'https://marcus.band/about/',
+    ogDescription: 'Engineer by trade. Guitarist by passion. Equally serious about both.'
+  };</script>
+  <script src="../assets/js/head.js"></script>
   <style>
     .gl-nav--page { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px); }
     .gl-scroll-hint {
@@ -223,30 +219,12 @@
       </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="gl-footer">
-      <div class="gl-footer-top">
-        <div class="gl-footer-mark">MM</div>
-        <div class="gl-footer-cols">
-          <div>
-            <div class="gl-footer-label">CONTACT</div>
-            <div>marcus@marcian.live</div>
-          </div>
-          <div>
-            <div class="gl-footer-label">FOLLOW</div>
-            <a href="https://www.instagram.com/musicianmarcus/" target="_blank" rel="noopener noreferrer">Instagram</a>
-          </div>
-        </div>
-      </div>
-      <div class="gl-footer-bot">
-        <span>© <script>document.write(new Date().getFullYear())</script> MARCUS MALDONADO</span>
-        <span>BUILT IN TEXAS</span>
-      </div>
-    </footer>
+    <div id="footer-mount"></div>
 
   </div>
 
   <script src="../assets/js/nav.js"></script>
+  <script src="../assets/js/footer.js"></script>
   <script>
     const hint = document.getElementById('scroll-hint');
     function checkScroll() {

--- a/docs/assets/js/footer.js
+++ b/docs/assets/js/footer.js
@@ -1,0 +1,25 @@
+(function() {
+  const mount = document.getElementById('footer-mount');
+  if (!mount) return;
+  const year = new Date().getFullYear();
+  mount.outerHTML = `
+    <footer class="gl-footer">
+      <div class="gl-footer-top">
+        <div class="gl-footer-mark">MM</div>
+        <div class="gl-footer-cols">
+          <div>
+            <div class="gl-footer-label">CONTACT</div>
+            <div>marcus@marcian.live</div>
+          </div>
+          <div>
+            <div class="gl-footer-label">FOLLOW</div>
+            <a href="https://www.instagram.com/musicianmarcus/" target="_blank" rel="noopener noreferrer">Instagram</a>
+          </div>
+        </div>
+      </div>
+      <div class="gl-footer-bot">
+        <span>© ${year} MARCUS MALDONADO</span>
+        <span>BUILT IN TEXAS</span>
+      </div>
+    </footer>`;
+})();

--- a/docs/assets/js/head.js
+++ b/docs/assets/js/head.js
@@ -1,0 +1,16 @@
+(function() {
+  const cfg = window.MM_PAGE || {};
+  const assets = new URL('../', document.currentScript.src).href;
+
+  document.head.insertAdjacentHTML('beforeend', `
+    <link rel="icon" type="image/x-icon" href="${assets}img/favicon.ico" />
+    <link rel="apple-touch-icon" href="${assets}img/apple-touch-icon.png" />
+    <meta property="og:title" content="${document.title}" />
+    <meta property="og:description" content="${cfg.ogDescription || ''}" />
+    <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
+    <meta property="og:url" content="${cfg.ogUrl || 'https://marcus.band'}" />
+    <meta property="og:type" content="website" />
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="${assets}css/styles.css">
+  `);
+})();

--- a/docs/assets/js/sheet.js
+++ b/docs/assets/js/sheet.js
@@ -1,0 +1,44 @@
+(function() {
+  const SHEET_URL = 'https://docs.google.com/spreadsheets/d/1emqiAiZPufCuJ0n9bkewzMdNzRAea9sJopSlLKkdqcs/export?format=csv';
+
+  function parseShowDate(dateStr) {
+    return dayjs(`${dateStr} ${dayjs().year()}`);
+  }
+
+  const fmt = {
+    day:       d => parseShowDate(d).format('DD'),
+    month:     d => parseShowDate(d).format('MMM').toUpperCase(),
+    week:      d => parseShowDate(d).format('ddd').toUpperCase(),
+    monthYear: d => parseShowDate(d).format('MMMM YYYY').toUpperCase(),
+  };
+
+  function adaptShow(row) {
+    const hasTickets = (row.ticket_url || '').trim();
+    const isPublic   = String(row.is_public || '').toLowerCase() === 'true';
+    return {
+      date:      (row.date || '').trim(),
+      artist:    (row.artist || '').trim(),
+      artistUrl: (row.artist_url || '').trim() || null,
+      venue:     (row.venue || '').trim(),
+      city:      `${(row.city || '').trim()}, ${(row.state || '').trim()}`,
+      status:    hasTickets ? 'tickets' : isPublic ? 'public' : 'private',
+      url:       hasTickets || null,
+      lat:       parseFloat(row.latitude),
+      lng:       parseFloat(row.longitude),
+    };
+  }
+
+  async function fetchShows() {
+    const res = await fetch(SHEET_URL);
+    const text = await res.text();
+    const rows = Papa.parse(text, { header: true, skipEmptyLines: true }).data;
+    const today = dayjs();
+    return rows
+      .map(adaptShow)
+      .filter(s => s.date && parseShowDate(s.date).isValid() && parseShowDate(s.date) >= today)
+      .sort((a, b) => parseShowDate(a.date) - parseShowDate(b.date));
+  }
+
+  window.MM = window.MM || {};
+  window.MM.Shows = { fetch: fetchShows, parseDate: parseShowDate, fmt };
+})();

--- a/docs/booking/index.html
+++ b/docs/booking/index.html
@@ -4,15 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Booking — Marcus Maldonado</title>
-  <link rel="icon" type="image/x-icon" href="../assets/img/favicon.ico" />
-  <meta property="og:title" content="Booking — Marcus Maldonado" />
-  <meta property="og:description" content="Available for weddings, corporate events, festivals, and session work. Domestic and international." />
-  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
-  <meta property="og:url" content="https://marcus.band/booking/" />
-  <meta property="og:type" content="website" />
-  <link rel="apple-touch-icon" href="../assets/img/apple-touch-icon.png" />
-  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../assets/css/styles.css">
+  <script>window.MM_PAGE = {
+    ogUrl: 'https://marcus.band/booking/',
+    ogDescription: 'Available for weddings, corporate events, festivals, and session work. Domestic and international.'
+  };</script>
+  <script src="../assets/js/head.js"></script>
   <style>
     html, body { height: 100%; overflow: hidden; }
     .gl-nav--page { position: relative; flex-shrink: 0; }
@@ -85,28 +81,10 @@
       </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="gl-footer">
-      <div class="gl-footer-top">
-        <div class="gl-footer-mark">MM</div>
-        <div class="gl-footer-cols">
-          <div>
-            <div class="gl-footer-label">CONTACT</div>
-            <div>marcus@marcian.live</div>
-          </div>
-          <div>
-            <div class="gl-footer-label">FOLLOW</div>
-            <a href="https://www.instagram.com/musicianmarcus/" target="_blank" rel="noopener noreferrer">Instagram</a>
-          </div>
-        </div>
-      </div>
-      <div class="gl-footer-bot">
-        <span>© <script>document.write(new Date().getFullYear())</script> MARCUS MALDONADO</span>
-        <span>BUILT IN TEXAS</span>
-      </div>
-    </footer>
+    <div id="footer-mount"></div>
 
   </div>
   <script src="../assets/js/nav.js"></script>
+  <script src="../assets/js/footer.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,15 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Marcus Maldonado — Guitarist</title>
-  <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico" />
-  <meta property="og:title" content="Marcus Maldonado — Guitarist" />
-  <meta property="og:description" content="Soulful, professional guitar performances for artists, weddings, and luxury experiences." />
-  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
-  <meta property="og:url" content="https://marcus.band" />
-  <meta property="og:type" content="website" />
-  <link rel="apple-touch-icon" href="assets/img/apple-touch-icon.png" />
-  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/styles.css">
+  <script>window.MM_PAGE = {
+    ogUrl: 'https://marcus.band',
+    ogDescription: 'Soulful, professional guitar performances for artists, weddings, and luxury experiences.'
+  };</script>
+  <script src="assets/js/head.js"></script>
   <style>
     html, body { height: 100%; overflow: hidden; }
     .gl-root.gl-home-only { height: 100%; display: flex; flex-direction: column; }
@@ -111,38 +107,16 @@
   <script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="assets/js/nav.js"></script>
+  <script src="assets/js/sheet.js"></script>
   <script>
-document.getElementById('home-year').textContent = new Date().getFullYear();
-const SHEET_URL = 'https://docs.google.com/spreadsheets/d/1emqiAiZPufCuJ0n9bkewzMdNzRAea9sJopSlLKkdqcs/export?format=csv';
+    document.getElementById('home-year').textContent = new Date().getFullYear();
 
-    function parseShowDate(dateStr) {
-      return dayjs(`${dateStr} ${dayjs().year()}`);
-    }
-
-    const fmtDay   = d => parseShowDate(d).format('DD');
-    const fmtMonth = d => parseShowDate(d).format('MMM').toUpperCase();
-
-    fetch(SHEET_URL)
-      .then(r => r.text())
-      .then(text => {
-        const rows = Papa.parse(text, { header: true, skipEmptyLines: true }).data;
-        const today = dayjs();
-        const shows = rows
-          .filter(r => r.date)
-          .map(r => ({
-            date: r.date,
-            artist: (r.artist || '').trim(),
-            venue: (r.venue || '').trim(),
-            city: `${(r.city || '').trim()}, ${(r.state || '').trim()}`,
-            status: (r.ticket_url || '').trim() ? 'tickets' : 'private',
-          }))
-          .filter(s => parseShowDate(s.date).isValid() && parseShowDate(s.date) >= today)
-          .sort((a, b) => parseShowDate(a.date) - parseShowDate(b.date));
-
+    MM.Shows.fetch()
+      .then(shows => {
         const next = shows[0];
         if (next) {
           document.getElementById('next-show-val').textContent =
-            `${fmtMonth(next.date)} ${fmtDay(next.date)} · ${next.artist}`;
+            `${MM.Shows.fmt.month(next.date)} ${MM.Shows.fmt.day(next.date)} · ${next.artist}`;
           document.getElementById('next-show-sub').textContent =
             next.status === 'private' ? 'Private engagement' : `${next.venue} — ${next.city}`;
         } else {

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -4,15 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tour Map — Marcus Maldonado</title>
-  <link rel="icon" type="image/x-icon" href="../assets/img/favicon.ico" />
-  <meta property="og:title" content="Tour Map — Marcus Maldonado" />
-  <meta property="og:description" content="Interactive tour map for guitarist Marcus Maldonado." />
-  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
-  <meta property="og:url" content="https://marcus.band/map/" />
-  <meta property="og:type" content="website" />
-  <link rel="apple-touch-icon" href="../assets/img/apple-touch-icon.png" />
-  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../assets/css/styles.css">
+  <script>window.MM_PAGE = {
+    ogUrl: 'https://marcus.band/map/',
+    ogDescription: 'Interactive tour map for guitarist Marcus Maldonado.'
+  };</script>
+  <script src="../assets/js/head.js"></script>
   <link rel="stylesheet" href="../assets/css/styles-tour-map.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <style>
@@ -156,42 +152,14 @@
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="../assets/js/nav.js"></script>
+  <script src="../assets/js/sheet.js"></script>
   <script>
     document.getElementById('map-year').textContent = new Date().getFullYear();
-    const SHEET_URL = 'https://docs.google.com/spreadsheets/d/1emqiAiZPufCuJ0n9bkewzMdNzRAea9sJopSlLKkdqcs/export?format=csv';
-
-    // Identical to showData.js — confirmed working
-    function parseShowDate(dateStr) {
-      return dayjs(`${dateStr} ${dayjs().year()}`);
-    }
-
-    const fmtDay   = d => parseShowDate(d).format('DD');
-    const fmtMonth = d => parseShowDate(d).format('MMM').toUpperCase();
-
-    async function fetchShows() {
-      const response = await fetch(SHEET_URL);
-      const text = await response.text();
-      const parsed = Papa.parse(text, { header: true, skipEmptyLines: true });
-      return parsed.data;
-    }
-
-    function adaptShow(row) {
-      const hasTickets = (row.ticket_url || '').trim();
-      const isPublic   = String(row.is_public || '').toLowerCase() === 'true';
-      return {
-        date: (row.date || '').trim(),
-        artist: (row.artist || '').trim(),
-        venue: (row.venue || '').trim(),
-        city: `${(row.city || '').trim()}, ${(row.state || '').trim()}`,
-        status: hasTickets ? 'tickets' : isPublic ? 'public' : 'private',
-        lat: parseFloat(row.latitude),
-        lng: parseFloat(row.longitude),
-      };
-    }
+    const { fmt } = MM.Shows;
 
     function updateNowCard(show, idx, total, progress) {
-      document.getElementById('now-day').textContent    = fmtDay(show.date);
-      document.getElementById('now-mo').textContent     = fmtMonth(show.date);
+      document.getElementById('now-day').textContent    = fmt.day(show.date);
+      document.getElementById('now-mo').textContent     = fmt.month(show.date);
       document.getElementById('now-artist').textContent = show.artist;
       document.getElementById('now-venue').textContent  = show.status === 'private' ? 'Private Event' : show.venue;
       document.getElementById('now-city').textContent   = show.city;
@@ -200,14 +168,7 @@
       document.getElementById('now-total').textContent = String(total).padStart(2, '0');
     }
 
-    fetchShows().then(rows => {
-        const today = dayjs();
-
-        const shows = rows
-          .map(adaptShow)
-          .filter(s => s.date && parseShowDate(s.date).isValid() && parseShowDate(s.date) >= today)
-          .sort((a, b) => parseShowDate(a.date) - parseShowDate(b.date));
-
+    MM.Shows.fetch().then(shows => {
         const mapShows = shows.filter(s => !isNaN(s.lat) && !isNaN(s.lng));
 
         if (!shows.length) return;
@@ -222,7 +183,7 @@
         document.getElementById('tm-cities').textContent  = uniqueCities;
         document.getElementById('now-total').textContent  = totalShows;
         const lastShow = shows[shows.length - 1];
-        const weeksOut = Math.ceil(parseShowDate(lastShow.date).diff(dayjs(), 'day') / 7);
+        const weeksOut = Math.ceil(MM.Shows.parseDate(lastShow.date).diff(dayjs(), 'day') / 7);
         document.getElementById('tm-lede').textContent    =
           `Over the next ${weeksOut} weeks, I have ${totalShows} shows across ${uniqueCities} ${uniqueCities === 1 ? 'city' : 'cities'}.`;
 

--- a/docs/tour/index.html
+++ b/docs/tour/index.html
@@ -4,15 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tour Dates — Marcus Maldonado</title>
-  <link rel="icon" type="image/x-icon" href="../assets/img/favicon.ico" />
-  <meta property="og:title" content="Tour Dates — Marcus Maldonado" />
-  <meta property="og:description" content="Upcoming shows and tour dates for guitarist Marcus Maldonado." />
-  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
-  <meta property="og:url" content="https://marcus.band/tour/" />
-  <meta property="og:type" content="website" />
-  <link rel="apple-touch-icon" href="../assets/img/apple-touch-icon.png" />
-  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../assets/css/styles.css">
+  <script>window.MM_PAGE = {
+    ogUrl: 'https://marcus.band/tour/',
+    ogDescription: 'Upcoming shows and tour dates for guitarist Marcus Maldonado.'
+  };</script>
+  <script src="../assets/js/head.js"></script>
   <style>
     .gl-root.gl-page { min-height: 100vh; }
     /* Loading skeleton */
@@ -84,67 +80,17 @@
       <div class="gl-loading">LOADING TOUR DATES…</div>
     </section>
 
-    <!-- Footer -->
-    <footer class="gl-footer">
-      <div class="gl-footer-top">
-        <div class="gl-footer-mark">MM</div>
-        <div class="gl-footer-cols">
-          <div>
-            <div class="gl-footer-label">CONTACT</div>
-            <div>marcus@marcian.live</div>
-          </div>
-          <div>
-            <div class="gl-footer-label">FOLLOW</div>
-            <a href="https://www.instagram.com/musicianmarcus/" target="_blank" rel="noopener noreferrer">Instagram</a>
-          </div>
-        </div>
-      </div>
-      <div class="gl-footer-bot">
-        <span>© <span id="footer-year"></span> MARCUS MALDONADO</span>
-        <span>BUILT IN TEXAS</span>
-      </div>
-    </footer>
+    <div id="footer-mount"></div>
 
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="../assets/js/nav.js"></script>
+  <script src="../assets/js/footer.js"></script>
+  <script src="../assets/js/sheet.js"></script>
   <script>
-    document.getElementById('footer-year').textContent = new Date().getFullYear();
-
-    const SHEET_URL = 'https://docs.google.com/spreadsheets/d/1emqiAiZPufCuJ0n9bkewzMdNzRAea9sJopSlLKkdqcs/export?format=csv';
-
-    // Exact same pattern as the working showData.js
-    function parseShowDate(dateStr) {
-      return dayjs(`${dateStr} ${dayjs().year()}`);
-    }
-
-    function fmtDay(d)       { return parseShowDate(d).format('DD'); }
-    function fmtMonth(d)     { return parseShowDate(d).format('MMM').toUpperCase(); }
-    function fmtWeek(d)      { return parseShowDate(d).format('ddd').toUpperCase(); }
-    function fmtMonthYear(d) { return parseShowDate(d).format('MMMM YYYY').toUpperCase(); }
-
-    async function fetchShows() {
-      const response = await fetch(SHEET_URL);
-      const text = await response.text();
-      const parsed = Papa.parse(text, { header: true, skipEmptyLines: true });
-      return parsed.data;
-    }
-
-    function adaptShow(row) {
-      const hasTickets = (row.ticket_url || '').trim();
-      const isPublic   = String(row.is_public || '').toLowerCase() === 'true';
-      return {
-        date: row.date,
-        artist: (row.artist || '').trim(),
-        artistUrl: (row.artist_url || '').trim() || null,
-        venue: (row.venue || '').trim(),
-        city: `${(row.city || '').trim()}, ${(row.state || '').trim()}`,
-        status: hasTickets ? 'tickets' : isPublic ? 'public' : 'private',
-        url: hasTickets || null,
-      };
-    }
+    const { fmt } = MM.Shows;
 
     function rowHTML(show, globalIndex) {
       const isPrivate = show.status === 'private';
@@ -158,10 +104,10 @@
         <article class="gl-row${isPrivate ? ' gl-row--private' : ''}">
           <div class="gl-row-i">${String(globalIndex + 1).padStart(2, '0')}</div>
           <div class="gl-row-date">
-            <div class="gl-row-day">${fmtDay(show.date)}</div>
-            <div class="gl-row-mo">${fmtMonth(show.date)}</div>
+            <div class="gl-row-day">${fmt.day(show.date)}</div>
+            <div class="gl-row-mo">${fmt.month(show.date)}</div>
           </div>
-          <div class="gl-row-week">${fmtWeek(show.date)}</div>
+          <div class="gl-row-week">${fmt.week(show.date)}</div>
           <div class="gl-row-venue">
             <div class="gl-row-name">${isPrivate ? 'Private Event' : show.venue}</div>
             <div class="gl-row-city">${show.city}</div>
@@ -174,7 +120,7 @@
     function groupByMonth(shows) {
       const groups = {};
       shows.forEach(show => {
-        const key = fmtMonthYear(show.date);
+        const key = fmt.monthYear(show.date);
         if (!groups[key]) groups[key] = [];
         groups[key].push(show);
       });
@@ -226,14 +172,7 @@
       });
     }
 
-    fetchShows().then(rows => {
-        const today = dayjs();
-        const allShows = rows
-          .map(adaptShow)
-          .filter(s => s.date && parseShowDate(s.date).isValid() && parseShowDate(s.date) >= today)
-          .sort((a, b) => parseShowDate(a.date) - parseShowDate(b.date));
-
-        // Stats
+    MM.Shows.fetch().then(allShows => {
         const cities = new Set(allShows.map(s => s.city)).size;
         const acts   = new Set(allShows.map(s => s.artist)).size;
 
@@ -241,11 +180,9 @@
         document.getElementById('stat-regions').textContent = cities;
         document.getElementById('stat-acts').textContent    = acts;
 
-        // Filters
         const artists = [...new Set(allShows.map(s => s.artist))];
         renderFilters(artists, 'All', allShows);
 
-        // Shows
         renderGrouped(allShows, allShows);
       })
       .catch(err => {


### PR DESCRIPTION
Closes #11.

### Summary
- Extracted three vanilla-JS modules under `docs/assets/js/` to eliminate boilerplate that had grown across the 5 pages:
  - **`head.js`** — injects favicon, OG tags, apple-touch-icon, Google Fonts, and the shared stylesheet. Each page sets `window.MM_PAGE = { ogUrl, ogDescription }` and includes the script. `<title>` stays in HTML and is read into `og:title` automatically.
  - **`footer.js`** — injects the full footer block (MM mark, CONTACT/FOLLOW columns, copyright with auto-updating year) at a `<div id="footer-mount">`. Used on `tour/`, `about/`, `booking/`.
  - **`sheet.js`** — single source of truth for tour data. Exposes `MM.Shows.fetch()`, `MM.Shows.parseDate()`, and `MM.Shows.fmt.{day,month,week,monthYear}`. Returns a unified show shape (includes `artistUrl`, `url`, `lat`, `lng`) so each page picks what it needs.
- Self-locating asset paths via `document.currentScript.src` — head.js works correctly from both the home page (`assets/js/head.js`) and inner pages (`../assets/js/head.js`) without any per-page config.

### Why
Updating a single value (Sheet URL, OG image, footer link, font) used to require a find-and-replace across 5 files. Now it's a one-line edit. Adding a new page is "include three scripts and provide a config object" instead of copying boilerplate from a sibling.

### Stats
- **8 files changed**, **134 insertions / 221 deletions** — net **-87 lines** while adding 3 reusable modules.
- Largest reductions: `tour/index.html` (-77), `map/index.html` (-43), `index.html` (-25).

### Constraints respected
- No bundler, no build step, no npm — same flat-file architecture as `nav.js`.
- No regressions in OG metadata: per-page `og:title`, `og:description`, `og:url` remain page-specific; shared values (image, type) are centralized.