### PR TITLE
Auto-zoom Map + Animated Stop Progression

### DIFF
--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -208,15 +208,24 @@
 
           let polyline, markers = [];
 
+          const pastStyle    = { radius: 4, color: '#0A0A0A', fillColor: '#0A0A0A', fillOpacity: 1, weight: 1 };
+          const currentStyle = { radius: 6, color: '#0A0A0A', fillColor: '#C8A96E', fillOpacity: 1, weight: 2 };
+
+          function addStop(latlng) {
+            if (markers.length > 0) markers[markers.length - 1].setStyle(pastStyle);
+            const marker = L.circleMarker(latlng, currentStyle).addTo(map);
+            markers.push(marker);
+          }
+
           function fitToProgress(stepIdx) {
             const visible = points.slice(0, stepIdx + 1);
             if (visible.length === 1) {
-              map.flyTo(visible[0], 5, { duration: 1.2 });
+              map.flyTo(visible[0], 5, { duration: 0.7 });
             } else {
               map.flyToBounds(visible, {
                 padding: [60, 60],
                 maxZoom: 7,
-                duration: 1.2,
+                duration: 0.7,
               });
             }
           }
@@ -234,10 +243,7 @@
               dashArray: '6 5',
             }).addTo(map);
 
-            const firstMarker = L.circleMarker(points[0], {
-              radius: 5, color: '#0A0A0A', fillColor: '#C8A96E', fillOpacity: 1, weight: 2,
-            }).addTo(map);
-            markers.push(firstMarker);
+            addStop(points[0]);
             fitToProgress(0);
 
             updateNowCard(mapShows[0], shows.indexOf(mapShows[0]), totalShows, 0);
@@ -250,21 +256,17 @@
               }
 
               polyline.addLatLng(points[step]);
-
-              const marker = L.circleMarker(points[step], {
-                radius: 5, color: '#0A0A0A', fillColor: '#C8A96E', fillOpacity: 1, weight: 2,
-              }).addTo(map);
-              markers.push(marker);
+              addStop(points[step]);
               fitToProgress(step);
 
               const progress = step / (points.length - 1);
               updateNowCard(mapShows[step], shows.indexOf(mapShows[step]), totalShows, progress);
 
               step++;
-              setTimeout(drawStep, 1500);
+              setTimeout(drawStep, 2000);
             }
 
-            setTimeout(drawStep, 1500);
+            setTimeout(drawStep, 2000);
           }
 
           setTimeout(() => {

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -208,6 +208,19 @@
 
           let polyline, markers = [];
 
+          function fitToProgress(stepIdx) {
+            const visible = points.slice(0, stepIdx + 1);
+            if (visible.length === 1) {
+              map.flyTo(visible[0], 5, { duration: 1.2 });
+            } else {
+              map.flyToBounds(visible, {
+                padding: [60, 60],
+                maxZoom: 7,
+                duration: 1.2,
+              });
+            }
+          }
+
           function animatePath() {
             let step = 1;
             if (polyline) polyline.remove();
@@ -225,13 +238,14 @@
               radius: 5, color: '#0A0A0A', fillColor: '#C8A96E', fillOpacity: 1, weight: 2,
             }).addTo(map);
             markers.push(firstMarker);
+            fitToProgress(0);
 
             updateNowCard(mapShows[0], shows.indexOf(mapShows[0]), totalShows, 0);
 
             function drawStep() {
               if (step >= points.length) {
                 updateNowCard(mapShows[mapShows.length - 1], shows.indexOf(mapShows[mapShows.length - 1]), totalShows, 1);
-                setTimeout(animatePath, 1200);
+                setTimeout(animatePath, 1600);
                 return;
               }
 
@@ -241,20 +255,21 @@
                 radius: 5, color: '#0A0A0A', fillColor: '#C8A96E', fillOpacity: 1, weight: 2,
               }).addTo(map);
               markers.push(marker);
+              fitToProgress(step);
 
               const progress = step / (points.length - 1);
               updateNowCard(mapShows[step], shows.indexOf(mapShows[step]), totalShows, progress);
 
               step++;
-              setTimeout(drawStep, 1000);
+              setTimeout(drawStep, 1500);
             }
 
-            setTimeout(drawStep, 1000);
+            setTimeout(drawStep, 1500);
           }
 
           setTimeout(() => {
             map.invalidateSize();
-            map.fitBounds(points, { padding: [40, 40] });
+            map.setView(points[0], 5);
             animatePath();
           }, 100);
         } else {


### PR DESCRIPTION
Closes #18.

### Summary
The flight map now recenters dynamically as each stop is plotted, instead of statically fitting all coordinates on load. The active dot is also visually distinct from past stops, and the animation cadence has been retuned so the route is easier to follow.

### What changed
- **Auto-zoom on each step.** New `fitToProgress(stepIdx)` helper calls `flyToBounds()` (or `flyTo()` for the single-point case) on the points-plotted-so-far, with `padding: [60, 60]`, `maxZoom: 7`, and a 0.7 s fly. Replaces the static `map.fitBounds(points, ...)` that used to lock the viewport on load.
- **Initial view**: `map.setView(points[0], 5)` so the map opens centered on the first stop instead of the full route's bounding box.
- **Active vs past stop styling.** New `addStop()` helper plots the current marker in `currentStyle` (radius 6, gold fill `#C8A96E`, dark stroke) and demotes the previous active marker via `setStyle(pastStyle)` (radius 4, solid black, thinner stroke). Result: the "now playing" dot pops while past stops recede into the trail.
- **Cadence tuning.** Step interval `1000 ms → 2000 ms`; first-step delay (after viewport settles on stop 1) `1000 ms → 2000 ms`; loop-restart pause `1200 ms → 1600 ms`. Animation feels less rushed and the final frame holds before looping.
- **Loop restart.** `animatePath()` re-entry calls `fitToProgress(0)` so the viewport flies smoothly back to the first stop instead of jumping.

### Files changed
- `docs/map/index.html` — single file, `+30 / −13`.

### Constraints respected
- No bundler, no build step, no new dependencies — uses Leaflet APIs (`flyTo`, `flyToBounds`, `setView`, `setStyle`) that are already available in the existing `1.9.4` CDN script.
- Page-specific animation logic stays inline per the prior refactor's conventions (the shared modules under `assets/js/` are unchanged).