### PR TITLE
Fix: adjust styles for short viewport to improve layout and readability

### DIFF
--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -26,6 +26,18 @@
       .tm-stage { flex: none; overflow: visible; }
       #flight-map { height: 280px; }
     }
+    @media (max-height: 960px) and (min-width: 769px) {
+      html, body { height: auto; overflow: auto; }
+      .gl-root.gl-page.tm-page { height: auto; }
+      .tm-stage { flex: none; overflow: visible; min-height: 800px; }
+      .tm-left { padding: 40px 40px 36px; }
+      .tm-title { font-size: 110px; }
+      .tm-lede { margin-top: 20px; }
+      .tm-stats { margin-top: 24px; padding: 16px 0; }
+      .tm-stat-num { font-size: 36px; }
+      .tm-now { padding-top: 20px; }
+      .tm-now-day { font-size: 44px; }
+    }
     /* Override leaflet defaults to blend with design */
     .leaflet-container { background: #F4F2EE; font-family: var(--mono, 'JetBrains Mono', monospace); }
     .gl-home-strip {


### PR DESCRIPTION
## Fix `/map/` clipping on short viewports

Closes #21.

### Summary
The map page locked the viewport to `100vh` with `overflow: hidden`, gated behind a `max-width: 768px` mobile escape hatch. Any window shorter than ~1000 px tall (Tesla Model 3 windowed at 1180 × 919, most laptops not fullscreened) hit the desktop layout and clipped the **"Now Playing"** card off the bottom of the left column with no way to scroll. This adds a height-based breakpoint that unlocks page scroll and tightens the left-column type/spacing so the two-column layout still fits comfortably.

### What changed
- **New `@media (max-height: 960px) and (min-width: 769px)` block** in the inline `<style>` of [docs/map/index.html](docs/map/index.html). The `min-width` guard keeps the existing `max-width: 768px` mobile rule cleanly in charge below 768 px wide.
- **Page scroll unlocked.** `html, body { overflow: auto }`, `.gl-root { height: auto }`, `.tm-stage { flex: none; min-height: 800px }` — root grows to fit content, page scrolls when the column is taller than the window. Two-column grid preserved.
- **Left-column type/spacing tightened** so the Now Playing card sits comfortably above the fold on a 919 px-tall viewport:
  - `.tm-title` `168px → 110px` (the dominant ~290 px → ~190 px tall)
  - `.tm-left` padding `56/56/48 → 40/40/36`
  - `.tm-stat-num` `44px → 36px`, `.tm-stats` padding `20 → 16`
  - `.tm-now-day` `56px → 44px`, `.tm-now` padding-top `28 → 20`
  - `.tm-lede` margin-top `28 → 20`

### Files changed
- [docs/map/index.html](docs/map/index.html) — single file, inline `<style>` only.

### Constraints respected
- No bundler, no build step, no new dependencies.
- Page-specific rules stay in the inline `<style>` of the map page (matches the existing convention for this layout's locked-viewport rules).
- Shared stylesheet [docs/assets/css/styles-tour-map.css](docs/assets/css/styles-tour-map.css) is unchanged.