### PR TITLE
Restore static OG meta tags for link-preview crawlers

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>About — Marcus Maldonado</title>
-  <script>window.MM_PAGE = {
-    ogUrl: 'https://marcus.band/about/',
-    ogDescription: 'Engineer by trade. Guitarist by passion. Equally serious about both.'
-  };</script>
+  <meta property="og:title" content="About — Marcus Maldonado" />
+  <meta property="og:description" content="Engineer by trade. Guitarist by passion. Equally serious about both." />
+  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
+  <meta property="og:url" content="https://marcus.band/about/" />
+  <meta property="og:type" content="website" />
+  <link rel="apple-touch-icon" href="../assets/img/apple-touch-icon.png" />
   <script src="../assets/js/head.js"></script>
   <style>
     .gl-nav--page { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(12px); }

--- a/docs/assets/js/head.js
+++ b/docs/assets/js/head.js
@@ -1,15 +1,8 @@
 (function() {
-  const cfg = window.MM_PAGE || {};
   const assets = new URL('../', document.currentScript.src).href;
 
   document.head.insertAdjacentHTML('beforeend', `
     <link rel="icon" type="image/x-icon" href="${assets}img/favicon.ico" />
-    <link rel="apple-touch-icon" href="${assets}img/apple-touch-icon.png" />
-    <meta property="og:title" content="${document.title}" />
-    <meta property="og:description" content="${cfg.ogDescription || ''}" />
-    <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
-    <meta property="og:url" content="${cfg.ogUrl || 'https://marcus.band'}" />
-    <meta property="og:type" content="website" />
     <link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="${assets}css/styles.css">
   `);

--- a/docs/booking/index.html
+++ b/docs/booking/index.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Booking — Marcus Maldonado</title>
-  <script>window.MM_PAGE = {
-    ogUrl: 'https://marcus.band/booking/',
-    ogDescription: 'Available for weddings, corporate events, festivals, and session work. Domestic and international.'
-  };</script>
+  <meta property="og:title" content="Booking — Marcus Maldonado" />
+  <meta property="og:description" content="Available for weddings, corporate events, festivals, and session work. Domestic and international." />
+  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
+  <meta property="og:url" content="https://marcus.band/booking/" />
+  <meta property="og:type" content="website" />
+  <link rel="apple-touch-icon" href="../assets/img/apple-touch-icon.png" />
   <script src="../assets/js/head.js"></script>
   <style>
     html, body { height: 100%; overflow: hidden; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Marcus Maldonado — Guitarist</title>
-  <script>window.MM_PAGE = {
-    ogUrl: 'https://marcus.band',
-    ogDescription: 'Soulful, professional guitar performances for artists, weddings, and luxury experiences.'
-  };</script>
+  <meta property="og:title" content="Marcus Maldonado — Guitarist" />
+  <meta property="og:description" content="Soulful, professional guitar performances for artists, weddings, and luxury experiences." />
+  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
+  <meta property="og:url" content="https://marcus.band" />
+  <meta property="og:type" content="website" />
+  <link rel="apple-touch-icon" href="assets/img/apple-touch-icon.png" />
   <script src="assets/js/head.js"></script>
   <style>
     html, body { height: 100%; overflow: hidden; }

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tour Map — Marcus Maldonado</title>
-  <script>window.MM_PAGE = {
-    ogUrl: 'https://marcus.band/map/',
-    ogDescription: 'Interactive tour map for guitarist Marcus Maldonado.'
-  };</script>
+  <meta property="og:title" content="Tour Map — Marcus Maldonado" />
+  <meta property="og:description" content="Interactive tour map for guitarist Marcus Maldonado." />
+  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
+  <meta property="og:url" content="https://marcus.band/map/" />
+  <meta property="og:type" content="website" />
+  <link rel="apple-touch-icon" href="../assets/img/apple-touch-icon.png" />
   <script src="../assets/js/head.js"></script>
   <link rel="stylesheet" href="../assets/css/styles-tour-map.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />

--- a/docs/tour/index.html
+++ b/docs/tour/index.html
@@ -4,10 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tour Dates — Marcus Maldonado</title>
-  <script>window.MM_PAGE = {
-    ogUrl: 'https://marcus.band/tour/',
-    ogDescription: 'Upcoming shows and tour dates for guitarist Marcus Maldonado.'
-  };</script>
+  <meta property="og:title" content="Tour Dates — Marcus Maldonado" />
+  <meta property="og:description" content="Upcoming shows and tour dates for guitarist Marcus Maldonado." />
+  <meta property="og:image" content="https://marcus.band/assets/img/mm-backdrop.jpg" />
+  <meta property="og:url" content="https://marcus.band/tour/" />
+  <meta property="og:type" content="website" />
+  <link rel="apple-touch-icon" href="../assets/img/apple-touch-icon.png" />
   <script src="../assets/js/head.js"></script>
   <style>
     .gl-root.gl-page { min-height: 100vh; }


### PR DESCRIPTION
Closes #23.

### Summary
After [#19](https://github.com/marcus-cse/mm-tour-site/pull/19) moved `<head>` boilerplate into [docs/assets/js/head.js](docs/assets/js/head.js), link-preview crawlers (iMessage, Slack, Discord, Facebook, Twitter, LinkedIn) stopped rendering preview cards for `marcus.band` URLs. Crawlers fetch the raw HTML and **do not execute JavaScript**, so the JS-injected `og:*` tags were invisible to them — every shared link rendered as a bare URL with no card, title, or thumbnail.

This PR moves `og:*` and `apple-touch-icon` back to **static HTML on each page**, and trims those concerns out of head.js. Favicon, fonts, and stylesheet stay in head.js — their audience is the browser, which does run JS, so the refactor's DRY benefit still holds for them.

### What changed
- **Per-page static tags** added to all 5 pages: `og:title`, `og:description`, `og:image`, `og:url`, `og:type`, and `apple-touch-icon`. Title/description/url are page-specific; `og:image` is the shared backdrop.
- **head.js trimmed** to just favicon + fonts + stylesheet. Dropped the `window.MM_PAGE` config read, the 5 `og:*` injections, the `apple-touch-icon` injection, and the `og:title` derivation from `document.title`.
- **`window.MM_PAGE` config removed** from all 5 pages (`grep -r MM_PAGE docs/` returns nothing).

### Files changed
- [docs/index.html](docs/index.html)
- [docs/tour/index.html](docs/tour/index.html)
- [docs/map/index.html](docs/map/index.html)
- [docs/about/index.html](docs/about/index.html)
- [docs/booking/index.html](docs/booking/index.html)
- [docs/assets/js/head.js](docs/assets/js/head.js)

### Tradeoff
This duplicates 5 OG values across 5 files instead of computing them from a shared template — partial walk-back of #19's DRY-ness. That's the cost of running on a static-HTML-only deploy with no build step. The browser-consumed boilerplate (favicon, fonts, styles) **stays** in head.js and still benefits from the refactor. Moving to a templating step / build-time injection is out of scope here; the goal is to restore link previews with the smallest possible change.