### PR TITLE
Map live cue + dashboard reorientation

### DIFF
--- a/docs/assets/css/styles-tour-map.css
+++ b/docs/assets/css/styles-tour-map.css
@@ -1,41 +1,49 @@
 /* ============================================================
-   TOUR MAP PAGE
+   TOUR MAP PAGE — dashboard layout
+   header bar (brand + stats) on top, full-width map below,
+   Now Playing card floats over the map (or stacks below on mobile)
    ============================================================ */
 .tm-page { background: var(--bg); color: var(--fg); }
 
 .tm-stage {
   flex: 1;
-  display: grid;
-  grid-template-columns: 0.85fr 1.15fr;
+  display: flex;
+  flex-direction: column;
   min-height: 0;
 }
 
-/* LEFT */
+/* HEADER (top bar) */
 .tm-left {
-  padding: 56px 56px 48px;
+  padding: 26px 48px 22px;
   display: flex;
-  flex-direction: column;
-  border-right: 1px solid var(--hairline);
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 56px;
+  border-bottom: 1px solid var(--hairline);
+  flex-shrink: 0;
+  min-width: 0;
+}
+.tm-brand {
+  flex: 1;
   min-width: 0;
 }
 .tm-eyebrow {
   display: flex;
-  justify-content: space-between;
+  gap: 24px;
   font-family: "JetBrains Mono", monospace;
   font-size: 11px;
   letter-spacing: 0.14em;
   color: var(--muted);
-  margin-bottom: 32px;
+  margin-bottom: 12px;
 }
 .tm-title {
   font-family: var(--display);
-  font-size: 168px;
+  font-size: 72px;
   line-height: 0.86;
   letter-spacing: -0.025em;
   margin: 0;
   font-weight: 400;
   text-transform: uppercase;
-  text-wrap: balance;
 }
 .tm-title em {
   font-style: normal;
@@ -44,25 +52,26 @@
   -webkit-text-fill-color: transparent;
 }
 .tm-lede {
-  font-size: 16px;
-  line-height: 1.55;
+  font-size: 13px;
+  line-height: 1.5;
   color: var(--fg-2);
-  max-width: 480px;
-  margin: 28px 0 0;
+  max-width: 560px;
+  margin: 12px 0 0;
   text-wrap: pretty;
 }
 
 .tm-stats {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  margin-top: 36px;
-  padding: 20px 0;
-  border-top: 1px solid var(--hairline);
-  border-bottom: 1px solid var(--hairline);
+  display: flex;
+  gap: 40px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  flex-shrink: 0;
 }
+.tm-stat { text-align: right; }
 .tm-stat-num {
   font-family: var(--display);
-  font-size: 44px;
+  font-size: 36px;
   line-height: 1;
   letter-spacing: -0.01em;
 }
@@ -75,17 +84,43 @@
   text-transform: uppercase;
 }
 
-/* Now Playing card */
+/* CANVAS — full-width map area */
+.tm-right {
+  flex: 1;
+  position: relative;
+  padding: 0;
+  background: var(--bg-2);
+  min-width: 0;
+  min-height: 0;
+}
+.tm-map-frame {
+  position: absolute;
+  inset: 0;
+  background: var(--bg);
+  border: none;
+  overflow: hidden;
+}
+.tm-tick { display: none; } /* legacy ticks unused in dashboard layout */
+
+/* Now Playing — floating overlay on map */
 .tm-now {
-  margin-top: auto;
-  padding-top: 28px;
+  position: absolute;
+  bottom: 24px;
+  left: 24px;
+  width: 340px;
+  padding: 18px 22px 16px;
+  background: var(--bg);
+  border: 1px solid var(--hairline);
+  z-index: 1000;
+  margin: 0;
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.10);
 }
 .tm-now-label {
   font-family: "JetBrains Mono", monospace;
   font-size: 10px;
   letter-spacing: 0.18em;
   color: var(--muted);
-  margin-bottom: 14px;
+  margin-bottom: 12px;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -104,46 +139,46 @@
 .tm-now-row {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 24px;
+  gap: 18px;
   align-items: center;
 }
 .tm-now-date {
   border-right: 1px solid var(--hairline);
-  padding-right: 24px;
+  padding-right: 18px;
 }
 .tm-now-day {
   font-family: var(--display);
-  font-size: 56px;
+  font-size: 36px;
   line-height: 1;
   letter-spacing: -0.02em;
 }
 .tm-now-mo {
   font-family: "JetBrains Mono", monospace;
-  font-size: 11px;
+  font-size: 10px;
   letter-spacing: 0.14em;
   color: var(--muted);
   margin-top: 4px;
 }
 .tm-now-artist {
   font-family: "JetBrains Mono", monospace;
-  font-size: 11px;
+  font-size: 10px;
   letter-spacing: 0.16em;
   color: var(--accent);
   text-transform: uppercase;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 .tm-now-venue {
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 500;
   letter-spacing: -0.01em;
 }
 .tm-now-city {
-  font-size: 13px;
+  font-size: 12px;
   color: var(--muted);
   margin-top: 2px;
 }
 .tm-now-bar {
-  margin-top: 18px;
+  margin-top: 14px;
   height: 2px;
   background: var(--hairline);
   position: relative;
@@ -166,34 +201,7 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* RIGHT — map */
-.tm-right {
-  position: relative;
-  padding: 32px;
-  background: var(--bg-2);
-  display: flex;
-  align-items: stretch;
-  justify-content: stretch;
-  min-width: 0;
-}
-.tm-map-frame {
-  position: relative;
-  flex: 1;
-  background: var(--bg);
-  border: 1px solid var(--hairline);
-}
-.tm-tick {
-  position: absolute;
-  width: 14px; height: 14px;
-  border-color: var(--fg);
-  border-style: solid;
-  border-width: 0;
-}
-.tm-tick--tl { top: -1px; left: -1px; border-top-width: 1px; border-left-width: 1px; }
-.tm-tick--tr { top: -1px; right: -1px; border-top-width: 1px; border-right-width: 1px; }
-.tm-tick--bl { bottom: -1px; left: -1px; border-bottom-width: 1px; border-left-width: 1px; }
-.tm-tick--br { bottom: -1px; right: -1px; border-bottom-width: 1px; border-right-width: 1px; }
-
+/* Legacy SVG-era styles retained for safety (not used by Leaflet path) */
 .tm-map-meta {
   position: absolute;
   font-family: "JetBrains Mono", monospace;
@@ -208,63 +216,16 @@
 .tm-map-meta--bl { bottom: 14px; left: 16px; }
 .tm-map-meta--br { bottom: 14px; right: 16px; text-align: right; }
 
-.tm-map {
-  width: 100%;
-  height: 100%;
-  display: block;
-}
-.tm-grat line {
-  stroke: var(--hairline);
-  stroke-width: 0.15;
-  vector-effect: non-scaling-stroke;
-}
-.tm-land path {
-  fill: var(--fg);
-  fill-opacity: 0.07;
-  stroke: var(--fg);
-  stroke-opacity: 0.35;
-  stroke-width: 0.4;
-  vector-effect: non-scaling-stroke;
-}
-.tm-route {
-  stroke: var(--accent);
-  stroke-width: 1.6;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  vector-effect: non-scaling-stroke;
-  filter: drop-shadow(0 0 4px var(--accent));
-}
-.tm-route-ghost {
-  stroke: var(--fg);
-  stroke-opacity: 0.18;
-  stroke-width: 0.6;
-  stroke-dasharray: 2 2;
-  vector-effect: non-scaling-stroke;
-}
-.tm-dots .tm-dot-core {
-  fill: var(--fg);
-  fill-opacity: 0.35;
-  transition: fill-opacity 0.25s, r 0.25s;
-}
-.tm-dots .tm-dot.is-reached .tm-dot-core {
-  fill: var(--accent);
-  fill-opacity: 1;
-}
-.tm-dots .tm-dot.is-active .tm-dot-core {
-  fill: var(--accent);
-  fill-opacity: 1;
-}
-.tm-dot-pulse {
-  fill: var(--accent);
-  fill-opacity: 0.25;
-  animation: tm-dot-pulse 1.4s infinite;
-  transform-origin: center;
-  transform-box: fill-box;
-}
-@keyframes tm-dot-pulse {
-  0% { transform: scale(0.6); fill-opacity: 0.45; }
-  100% { transform: scale(2.4); fill-opacity: 0; }
-}
+.tm-map { width: 100%; height: 100%; display: block; }
+.tm-grat line { stroke: var(--hairline); stroke-width: 0.15; vector-effect: non-scaling-stroke; }
+.tm-land path { fill: var(--fg); fill-opacity: 0.07; stroke: var(--fg); stroke-opacity: 0.35; stroke-width: 0.4; vector-effect: non-scaling-stroke; }
+.tm-route { stroke: var(--accent); stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; vector-effect: non-scaling-stroke; filter: drop-shadow(0 0 4px var(--accent)); }
+.tm-route-ghost { stroke: var(--fg); stroke-opacity: 0.18; stroke-width: 0.6; stroke-dasharray: 2 2; vector-effect: non-scaling-stroke; }
+.tm-dots .tm-dot-core { fill: var(--fg); fill-opacity: 0.35; transition: fill-opacity 0.25s, r 0.25s; }
+.tm-dots .tm-dot.is-reached .tm-dot-core { fill: var(--accent); fill-opacity: 1; }
+.tm-dots .tm-dot.is-active .tm-dot-core { fill: var(--accent); fill-opacity: 1; }
+.tm-dot-pulse { fill: var(--accent); fill-opacity: 0.25; animation: tm-dot-pulse 1.4s infinite; transform-origin: center; transform-box: fill-box; }
+@keyframes tm-dot-pulse { 0% { transform: scale(0.6); fill-opacity: 0.45; } 100% { transform: scale(2.4); fill-opacity: 0; } }
 
 .tm-legend {
   position: absolute;
@@ -282,42 +243,43 @@
   border: 1px solid var(--hairline);
 }
 .tm-legend-row { display: flex; align-items: center; gap: 8px; }
-.tm-leg-swatch {
-  width: 8px; height: 8px;
-  display: inline-block;
-  background: var(--fg);
-}
+.tm-leg-swatch { width: 8px; height: 8px; display: inline-block; background: var(--fg); }
 .tm-leg-swatch--public { background: var(--accent); border-radius: 50%; }
 .tm-leg-swatch--private { background: transparent; border: 1px solid var(--fg); border-radius: 50%; }
-.tm-leg-swatch--route {
-  width: 18px; height: 1.5px;
-  background: var(--accent);
-}
+.tm-leg-swatch--route { width: 18px; height: 1.5px; background: var(--accent); }
 
+/* Mobile — stacked layout, Now Playing as full-width card below the map */
 @media (max-width: 768px) {
-  .tm-stage {
-    display: flex;
-    flex-direction: column;
-  }
-  .tm-right {
-    order: -1;
-    height: 280px;
-    flex-shrink: 0;
-    background: var(--bg-2);
-  }
-  .tm-map-frame {
-    height: 100%;
-  }
   .tm-left {
-    padding: 32px 24px 40px;
-    border-right: none;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 22px 24px;
+    gap: 18px;
+  }
+  .tm-brand { width: 100%; }
+  .tm-eyebrow { margin-bottom: 12px; }
+  .tm-title { font-size: 48px; line-height: 0.92; }
+  .tm-lede { display: none; }
+  .tm-stats {
+    width: 100%;
+    justify-content: space-between;
+    gap: 16px;
+    padding-top: 14px;
     border-top: 1px solid var(--hairline);
   }
-  .tm-lede { display: none; }
-  .tm-title { font-size: 72px; line-height: 0.9; }
-  .tm-eyebrow { margin-bottom: 16px; }
-  .tm-stats { margin-top: 24px; }
-  .tm-now { margin-top: 28px; padding-top: 20px; }
+  .tm-stat { text-align: left; }
+  .tm-stat-num { font-size: 26px; }
+
+  .tm-now {
+    position: static;
+    width: auto;
+    box-shadow: none;
+    border: none;
+    border-top: 1px solid var(--hairline);
+    padding: 22px 24px;
+  }
+  .tm-now-day { font-size: 32px; }
+  .tm-now-venue { font-size: 14px; }
 }
 
 /* Pulsing ring on the active map marker */

--- a/docs/assets/css/styles-tour-map.css
+++ b/docs/assets/css/styles-tour-map.css
@@ -128,7 +128,7 @@
 .tm-pulse {
   display: inline-block;
   width: 7px; height: 7px;
-  background: var(--accent);
+  background: #C8A96E;
   border-radius: 50%;
   animation: tm-pulse 1.6s infinite;
 }

--- a/docs/assets/css/styles-tour-map.css
+++ b/docs/assets/css/styles-tour-map.css
@@ -319,3 +319,21 @@
   .tm-stats { margin-top: 24px; }
   .tm-now { margin-top: 28px; padding-top: 20px; }
 }
+
+/* Pulsing ring on the active map marker */
+.tm-pulse-marker { pointer-events: none; }
+.tm-pulse-ring {
+  display: block;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent);
+  background: transparent;
+  animation: tm-pulse-ring 1.6s ease-out infinite;
+  transform-origin: center;
+  will-change: transform, opacity;
+}
+@keyframes tm-pulse-ring {
+  0%   { transform: scale(0.4); opacity: 0.9; }
+  100% { transform: scale(1.6); opacity: 0; }
+}

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -18,27 +18,13 @@
     .gl-root.gl-page.tm-page { height: 100%; display: flex; flex-direction: column; }
     .gl-nav--page { position: relative; flex-shrink: 0; }
     .tm-stage { flex: 1; min-height: 0; overflow: hidden; }
-    .tm-right { padding: 0; }
-    .tm-map-frame { border: none; }
     #flight-map { width: 100%; height: 100%; }
-    .tm-map-frame { position: relative; overflow: hidden; }
     @media (max-width: 768px) {
       html, body { height: auto; overflow: auto; }
       .gl-root.gl-page.tm-page { height: auto; }
       .tm-stage { flex: none; overflow: visible; }
-      #flight-map { height: 280px; }
-    }
-    @media (max-height: 960px) and (min-width: 769px) {
-      html, body { height: auto; overflow: auto; }
-      .gl-root.gl-page.tm-page { height: auto; }
-      .tm-stage { flex: none; overflow: visible; min-height: 800px; }
-      .tm-left { padding: 40px 40px 36px; }
-      .tm-title { font-size: 110px; }
-      .tm-lede { margin-top: 20px; }
-      .tm-stats { margin-top: 24px; padding: 16px 0; }
-      .tm-stat-num { font-size: 36px; }
-      .tm-now { padding-top: 20px; }
-      .tm-now-day { font-size: 44px; }
+      .tm-right { display: flex; flex-direction: column; height: auto; }
+      .tm-map-frame { position: relative; height: 320px; flex-shrink: 0; }
     }
     /* Override leaflet defaults to blend with design */
     .leaflet-container { background: #F4F2EE; font-family: var(--mono, 'JetBrains Mono', monospace); }
@@ -85,24 +71,25 @@
       <a href="../booking/" class="gl-nav-overlay-cta">Inquire</a>
     </div>
 
-    <!-- Two-column stage -->
+    <!-- Dashboard stage: header bar on top, full-width map below with Now Playing overlay -->
     <div class="tm-stage">
 
-      <!-- LEFT: title + stats + now playing -->
-      <div class="tm-left">
-        <div class="tm-eyebrow">
-          <span>TOUR MAP</span>
-          <span id="tm-season">2026 SEASON</span>
+      <!-- HEADER: brand + stats -->
+      <header class="tm-left">
+        <div class="tm-brand">
+          <div class="tm-eyebrow">
+            <span>TOUR MAP</span>
+            <span id="tm-season">2026 SEASON</span>
+          </div>
+
+          <h1 class="tm-title">
+            ON THE <em>ROAD.</em>
+          </h1>
+
+          <p class="tm-lede" id="tm-lede">
+            Loading tour dates…
+          </p>
         </div>
-
-        <h1 class="tm-title">
-          ON THE<br>
-          <em>ROAD.</em>
-        </h1>
-
-        <p class="tm-lede" id="tm-lede">
-          Loading tour dates…
-        </p>
 
         <div class="tm-stats">
           <div class="tm-stat">
@@ -118,8 +105,14 @@
             <div class="tm-stat-lbl">Acts</div>
           </div>
         </div>
+      </header>
 
-        <!-- Now playing card -->
+      <!-- CANVAS: map with Now Playing card as floating overlay (or stacked card on mobile) -->
+      <div class="tm-right">
+        <div class="tm-map-frame">
+          <div id="flight-map"></div>
+        </div>
+
         <div class="tm-now">
           <div class="tm-now-label">
             NOW PLAYING <span class="tm-pulse"></span>
@@ -143,15 +136,6 @@
             <span>/</span>
             <span id="now-total">—</span>
           </div>
-        </div>
-      </div>
-
-      <!-- RIGHT: SVG map -->
-      <div class="tm-right">
-        <div class="tm-map-frame">
-          <!-- Leaflet map -->
-          <div id="flight-map"></div>
-
         </div>
       </div>
     </div>
@@ -217,7 +201,7 @@
         const lastShow = shows[shows.length - 1];
         const weeksOut = Math.ceil(MM.Shows.parseDate(lastShow.date).diff(dayjs(), 'day') / 7);
         document.getElementById('tm-lede').textContent    =
-          `Over the next ${weeksOut} weeks, I have ${totalShows} shows across ${uniqueCities} ${uniqueCities === 1 ? 'city' : 'cities'}.`;
+          `Over the next ${weeksOut} weeks, Marcus has ${totalShows} shows across ${uniqueCities} ${uniqueCities === 1 ? 'city' : 'cities'}.`;
 
         updateNowCard(shows[0], 0, totalShows, 0);
 

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -224,15 +224,38 @@
         if (mapShows.length > 0) {
           const points = mapShows.map(s => [s.lat, s.lng]);
 
+          // Ghost route — drawn once, persists for the session.
+          // Visible during the Dallas → stop-1 fly so the route arrives into frame.
+          L.polyline(points, {
+            color: '#0A0A0A',
+            weight: 1,
+            opacity: 0.18,
+            dashArray: '2 4',
+            interactive: false,
+          }).addTo(map);
+
           let polyline, markers = [];
 
           const pastStyle    = { radius: 4, color: '#0A0A0A', fillColor: '#0A0A0A', fillOpacity: 1, weight: 1 };
           const currentStyle = { radius: 6, color: '#0A0A0A', fillColor: '#C8A96E', fillOpacity: 1, weight: 2 };
 
+          const pulseIcon = L.divIcon({
+            className: 'tm-pulse-marker',
+            html: '<span class="tm-pulse-ring"></span>',
+            iconSize: [40, 40],
+            iconAnchor: [20, 20],
+          });
+          let pulseMarker = null;
+
           function addStop(latlng) {
             if (markers.length > 0) markers[markers.length - 1].setStyle(pastStyle);
             const marker = L.circleMarker(latlng, currentStyle).addTo(map);
             markers.push(marker);
+            if (!pulseMarker) {
+              pulseMarker = L.marker(latlng, { icon: pulseIcon, interactive: false, keyboard: false }).addTo(map);
+            } else {
+              pulseMarker.setLatLng(latlng);
+            }
           }
 
           function fitToProgress(stepIdx) {


### PR DESCRIPTION
Closes #25.

### Summary
The `/map/` page now reads as a live, animated dashboard rather than a static graphic. Two layered fixes: (a) the map itself carries its own "live" affordance via a ghost route + pulsing ring on the active stop, and (b) the page is reorganized so the **Now Playing card is always in the same viewport as the map**, with a top header bar and a full-width map below.

### What changed

#### 1. Map-side live cue
- **Ghost route** drawn through all `points` once `MM.Shows.fetch()` resolves (faint dashed `L.polyline`, `interactive: false`). Visible during the Dallas → stop-1 fly so the user sees the route arrive into frame, then persists for the whole session (never removed on loop restart).
- **Pulsing gold ring on the active marker** via an `L.divIcon` repositioned through `setLatLng()` whenever `addStop()` runs. CSS-driven `transform: scale()` + `opacity` animation only — no layout/paint thrash, no jank during `flyTo` transitions. Border-only ring (transparent fill) so the gold dot stays visible inside.

#### 2. Dashboard reorientation
- **Top header bar** replaces the old left column: eyebrow + smaller "ON THE ROAD." title (168 px → 72 px, single line) + lede on the left, three stats on the right, hairline divider below.
- **Full-width map canvas** below the header, fills the remaining viewport.
- **Now Playing card as a floating overlay** in the bottom-left of the map (340 px wide, hairline border, soft shadow). Always visible inside the same frame as the map.
- **Mobile (≤ 768 px)** — header stacks (brand → stats), map gets explicit 320 px height, Now Playing becomes a full-width static card below the map. Same `tm-now` element adapts via `position: static`; no DOM duplication.
- **`max-height: 960px` short-viewport override removed** — no longer needed; the new chrome (~150-180 px header) fits comfortably even at 919 px tall, so the locked-viewport layout works at any reasonable height without falling back to scroll mode.
- **Legacy corner ticks (`.tm-tick--*`) hidden** — they belonged to the old boxed two-column treatment.
- **`z-index: 1000`** on `.tm-now` so it sits above any Leaflet UI panes.

#### 3. Copy + visual polish
- **Lede update**: `"I have"` → `"Marcus has"` (third-person reads cleaner under the page's heading framing).
- **Now Playing pulse color** matched to the map's active dot — was `var(--accent)` (which is `#0A0A0A` globally), now `#C8A96E` (gold), so the card's pulse and the map's active marker share a color identity.

### Files changed
- [docs/map/index.html](docs/map/index.html) — body markup restructured, inline `<style>` simplified, Leaflet script extended (ghost polyline + divIcon pulse marker tracking inside `addStop()`), lede copy tweak.
- [docs/assets/css/styles-tour-map.css](docs/assets/css/styles-tour-map.css) — layout sections rewritten for the dashboard shape; `.tm-now` becomes an absolutely-positioned overlay; mobile breakpoint simplified; `.tm-pulse-marker` / `.tm-pulse-ring` rules + `@keyframes tm-pulse-ring` added; `.tm-pulse` background color flipped to gold.

### Constraints respected
- No new dependencies. Uses Leaflet APIs already in scope (`L.divIcon`, `L.marker`, `L.polyline`, `setLatLng`).
- Page-specific layout/animation logic stays in the map's own files; shared modules under [docs/assets/js/](docs/assets/js/) untouched.
- The dead SVG-era `.tm-route-ghost` / `.tm-dot-pulse` styles in the stylesheet remain in place (out of scope; not removed in this PR).
