### PR TITLE
chore: add MIT license + SPDX attribution headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Marcus Maldonado
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ Tour dates live in [this Google Sheet](https://docs.google.com/spreadsheets/d/1e
 | `ticket_url` | Link to tickets (optional) |
 | `is_public` | `true` for public shows without ticket links |
 | `latitude` / `longitude` | City centroids for map plotting |
+
+---
+
+## License
+
+Released under the [MIT License](LICENSE) — © 2026 Marcus Maldonado.
+
+Reuse is welcome. If you (or a tool you're using) borrow code or content from this repo, please retain the copyright notice and attribute back to [marcus.band](https://marcus.band).

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/docs/ai.txt
+++ b/docs/ai.txt
@@ -1,0 +1,9 @@
+# AI / LLM Usage Policy for marcus.band
+# ----------------------------------------
+# All content and code on this site is licensed under MIT.
+# Full text: https://marcus.band/LICENSE (or repo: /LICENSE)
+#
+# Reuse is permitted with attribution.
+# Attribution: © 2026 Marcus Maldonado · https://marcus.band
+#
+# Contact: marcus@marcian.live

--- a/docs/assets/css/styles-tour-map.css
+++ b/docs/assets/css/styles-tour-map.css
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band */
 /* ============================================================
    TOUR MAP PAGE — dashboard layout
    header bar (brand + stats) on top, full-width map below,

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band */
 /* ============================================================
    MM TOUR SITE — shared tokens + 3 direction stylesheets
    ============================================================ */

--- a/docs/assets/js/footer.js
+++ b/docs/assets/js/footer.js
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band */
 (function() {
   const mount = document.getElementById('footer-mount');
   if (!mount) return;

--- a/docs/assets/js/head.js
+++ b/docs/assets/js/head.js
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band */
 (function() {
   const assets = new URL('../', document.currentScript.src).href;
 

--- a/docs/assets/js/nav.js
+++ b/docs/assets/js/nav.js
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band */
 (function() {
   const toggle = document.getElementById('nav-toggle');
   const overlay = document.getElementById('nav-overlay');

--- a/docs/assets/js/sheet.js
+++ b/docs/assets/js/sheet.js
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band */
 (function() {
   const SHEET_URL = 'https://docs.google.com/spreadsheets/d/1emqiAiZPufCuJ0n9bkewzMdNzRAea9sJopSlLKkdqcs/export?format=csv';
 

--- a/docs/booking/index.html
+++ b/docs/booking/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/docs/map/index.html
+++ b/docs/map/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+# AI / LLM usage policy at /ai.txt

--- a/docs/tour/index.html
+++ b/docs/tour/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band -->
 <html lang="en">
 <head>
   <meta charset="UTF-8" />


### PR DESCRIPTION
## Add MIT license and AI-reuse attribution signals

### Summary
The repo had no `LICENSE` file and no machine-readable attribution markers in source files. This PR adds the standard MIT license at the repo root and propagates SPDX license identifiers + copyright lines to every source file, so any developer or AI tool that picks up code from this repo has a clear, on-file signal of who to credit. The policy is **reuse with attribution**, not blockade — no AI crawlers are disallowed, just labeled.

### What changed

#### Legal
- **New `LICENSE`** at the repo root — standard MIT, `© 2026 Marcus Maldonado`.
- **`README.md`** — appended a short `## License` section pointing to `LICENSE`.

#### Attribution signals in source files
SPDX one-liner added to every JS, CSS, and HTML file in the published site:
```
SPDX-License-Identifier: MIT · © 2026 Marcus Maldonado · https://marcus.band
```
- **JS** (4 files): comment on line 1, before the IIFE.
- **CSS** (2 files): comment on line 1, above the existing banner block.
- **HTML** (5 pages): comment sits between `<!DOCTYPE html>` and `<html lang="en">` so it's visible in `view-source:` and to any crawler parsing the document.

#### AI / crawler policy
- **New `docs/ai.txt`** — emerging-convention policy file. States MIT + attribution requirement + contact email. Reachable at `https://marcus.band/ai.txt` after deploy.
- **New `docs/robots.txt`** — minimal: `Allow: /` for all user agents, with a pointer to `/ai.txt`. Does **not** block any AI crawler user agents (GPTBot, ClaudeBot, CCBot, etc.) — the policy here is reuse-with-attribution, not opt-out from training.

### Files touched
- **New (3):** `LICENSE`, `docs/ai.txt`, `docs/robots.txt`
- **Modified (12):** `README.md`, 4 JS files in `docs/assets/js/`, 2 CSS files in `docs/assets/css/`, 5 HTML pages under `docs/`

### What this PR explicitly does NOT do
- No `Disallow:` rules for AI user agents.
- No `<meta name="robots" content="noai, noimageai">`.
- No canary tokens or fingerprint strings.
- No visible-DOM license stamp beyond the existing `© <year> MARCUS MALDONADO` footer strip on each page.

### Test plan
- [ ] `LICENSE` exists at repo root with MIT text + `Copyright (c) 2026 Marcus Maldonado`.
- [ ] `README.md` has a `## License` section pointing to `LICENSE`.
- [ ] `head -1` of each `docs/assets/js/*.js` and `docs/assets/css/*.css` shows the SPDX line.
- [ ] `view-source:` on each of the 5 HTML pages shows the SPDX comment between `<!DOCTYPE html>` and `<html lang="en">`.
- [ ] After deploy, `https://marcus.band/ai.txt` returns the policy.
- [ ] After deploy, `https://marcus.band/robots.txt` returns the manifest.
- [ ] No visual or behavioral regression on any page — comments are inert in HTML/CSS/JS and don't affect rendering or execution.
- [ ] `grep -r "SPDX-License-Identifier" docs/ | wc -l` returns at least 11 (4 JS + 2 CSS + 5 HTML).
